### PR TITLE
[AM-3483] --include-test-branch로 deploy 명령 실행 시, origin/test rebase 전에 git fetch 명령어 추가

### DIFF
--- a/git-deploy
+++ b/git-deploy
@@ -98,8 +98,9 @@ echo ""
 if [ $is_override -eq 1 ]
   then
   echo "현재 브랜치($local_deploy_branch)를 $remote_deploy_branch 브랜치 위로 리베이스합니다."
-  echo "git rebase $remote_deploy_branch"
+  echo "git fetch"
   git fetch
+  echo "git rebase $remote_deploy_branch"
   git rebase $remote_deploy_branch || exit_on_failed "오류가 발생했습니다. 문제를 해결하고 다시 시도하거나 수동으로 진행해주세요"
 
   echo ""

--- a/git-deploy
+++ b/git-deploy
@@ -99,6 +99,7 @@ if [ $is_override -eq 1 ]
   then
   echo "현재 브랜치($local_deploy_branch)를 $remote_deploy_branch 브랜치 위로 리베이스합니다."
   echo "git rebase $remote_deploy_branch"
+  git fetch
   git rebase $remote_deploy_branch || exit_on_failed "오류가 발생했습니다. 문제를 해결하고 다시 시도하거나 수동으로 진행해주세요"
 
   echo ""


### PR DESCRIPTION
## 요약
앤트맨에서 --include-test-branch를 포함한 상태로 deploy 명령어 실행 시, origin/test를 리베이스 하게 되는데
업데이트 전의 origin/test를 rebase 하는 경우가 생겨서 이전 작업자의 커밋이 날라가는 경우가 생겼습니다.
그래서 rebase 하기 전에 git fetch를 선행하도록 명령어를 추가해보았습니다 :eyes: